### PR TITLE
Misc improvements

### DIFF
--- a/IIfA/IIfA.lua
+++ b/IIfA/IIfA.lua
@@ -21,7 +21,7 @@ if IIfA == nil then IIfA = {} end
 --local IIfA = IIfA
 
 IIfA.name 				= "Inventory Insight"
-IIfA.version 			= "3.12"
+IIfA.version 			= "3.13"
 IIfA.author 			= "AssemblerManiac & manavortex"
 IIfA.defaultAlertSound 	= nil
 IIfA.colorHandler 		= nil
@@ -179,6 +179,7 @@ function IIfA_onLoad(eventCode, addOnName)
 		bDebug 					= false,
 		in2TextColors 			= IIFA_COLORDEF_DEFAULT:ToHex(),
 		showItemCountOnRight 	= true,
+		showItemStats			= false,
 		b_collectHouses			= false,
 		collectHouseData		= {},
 		ignoredCharEquipment	= {},
@@ -210,7 +211,8 @@ function IIfA_onLoad(eventCode, addOnName)
 	-- initializing default values
 	local default = {
 		in2TextColors = IIFA_COLORDEF_DEFAULT:ToHex(),
-		showItemCountOnRight = true,
+		showItemCountOnRight	= true,
+		showItemStats			= false,
 
 		frameSettings =
 			{
@@ -379,7 +381,6 @@ function IIfA_onLoad(eventCode, addOnName)
 		IIfA.bFilterOnSetName = false
 		ObjSettings.bFilterOnSetName = false
 	end
-	-- IIFA_GUI_SetNameOnly_Checked:SetHidden(not IIfA.bFilterOnSetName)
 
 	IIFA_GUI_Header_Filter_Button0:SetState(BSTATE_PRESSED)
 	IIfA.LastFilterControl = IIFA_GUI_Header_Filter_Button0
@@ -394,6 +395,8 @@ function IIfA_onLoad(eventCode, addOnName)
 	IIfA.colorHandler = ZO_ColorDef:New(ObjSettings.in2TextColors)
 	SLASH_COMMANDS["/ii"] = IIfA_SlashCommands
 	IIfA:CreateSettingsWindow(IIfA.settings, default)
+
+	IIFA_GUI_ListHolder_Counts:SetHidden(not IIfA:GetSettings().showItemStats)
 
 	IIfA.CharCurrencyFrame:Initialize(IIfA.data)
 	IIfA.CharBagFrame:Initialize(IIfA.data)

--- a/IIfA/IIfA.txt
+++ b/IIfA/IIfA.txt
@@ -1,6 +1,6 @@
 ## Title: Inventory Insight
 ## Author: manavortex, AssemblerManiac
-## Version: 3.12
+## Version: 3.13
 ## APIVersion: 100022
 ## SavedVariables: IIfA_Settings IIfA_Data
 ## OptionalDependsOn: libFilters pChat

--- a/IIfA/IIfA.xml
+++ b/IIfA/IIfA.xml
@@ -157,12 +157,12 @@
 								<Button name="$(parent)_Button0">
 									<Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="0"/>
 									<Dimensions x="40" y="40" />
-									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized>
+<!--									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized>	-->
 									<OnMouseEnter>IIfA:GuiShowFilterTooltip(self, "All Items")</OnMouseEnter>
 									<OnMouseExit>IIfA:GuiHideTooltip(self)</OnMouseExit>
 									<OnMouseUp>IIfA:GuiOnFilterButton(self, button, "All", nil)</OnMouseUp>
 									<Textures normal="EsoUI/art/inventory/inventory_tabicon_all_up.dds"
-												pressed="EsoUI/art/inventory/inventory_tabicon_all_down.dds"
+												pressed="EsoUI/art/inventory/inventory_tabicon_all_down.duntds"
 												mouseOver="EsoUI/art/inventory/inventory_tabicon_all_over.dds"
 									/>
 
@@ -170,7 +170,7 @@
 								<Button name="$(parent)_Button1">
 									<Anchor point="TOPRIGHT" relativeTo="$(parent)_Button0" relativePoint="TOPRIGHT" offsetX="50" offsetY="0"/>
 									<Dimensions x="40" y="40" />
-									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized>
+<!--									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized> -->
 									<OnMouseEnter>IIfA:GuiShowFilterTooltip(self, "Weapons")</OnMouseEnter>
 									<OnMouseExit>IIfA:GuiHideTooltip(self)</OnMouseExit>
 									<OnMouseUp>IIfA:GuiOnFilterButton(self, button, "Weapons", nil)</OnMouseUp>
@@ -182,7 +182,7 @@
 								<Button name="$(parent)_Button2">
 									<Anchor point="TOPRIGHT" relativeTo="$(parent)_Button1" relativePoint="TOPRIGHT" offsetX="50" offsetY="0"/>
 									<Dimensions x="40" y="40" />
-									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized>
+<!--									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized> -->
 									<OnMouseEnter>IIfA:GuiShowFilterTooltip(self, "Armor")</OnMouseEnter>
 									<OnMouseExit>IIfA:GuiHideTooltip(self)</OnMouseExit>
 									<OnMouseUp>IIfA:GuiOnFilterButton(self, button, "Body", nil)</OnMouseUp>
@@ -194,7 +194,7 @@
 								<Button name="$(parent)_Button3">
 									<Anchor point="TOPRIGHT" relativeTo="$(parent)_Button2" relativePoint="TOPRIGHT" offsetX="50" offsetY="0"/>
 									<Dimensions x="40" y="40" />
-									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized>
+<!--									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized> -->
 									<OnMouseEnter>IIfA:GuiShowFilterTooltip(self, "Consumables")</OnMouseEnter>
 									<OnMouseExit>IIfA:GuiHideTooltip(self)</OnMouseExit>
 									<OnMouseUp>IIfA:GuiOnFilterButton(self, button, "Consumable", {ITEMTYPE_CONTAINER, ITEMTYPE_FOOD, ITEMTYPE_DRINK, ITEMTYPE_POTION, ITEMTYPE_POISON, ITEMTYPE_RECIPE, ITEMTYPE_RACIAL_STYLE_MOTIF, ITEMTYPE_AVA_REPAIR, ITEMTYPE_TOOL, ITEMTYPE_CROWN_REPAIR})</OnMouseUp>
@@ -206,7 +206,7 @@
 								<Button name="$(parent)_Button4">
 									<Anchor point="TOPRIGHT" relativeTo="$(parent)_Button3" relativePoint="TOPRIGHT" offsetX="50" offsetY="0"/>
 									<Dimensions x="40" y="40" />
-									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized>
+<!--									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized> -->
 									<OnMouseEnter>IIfA:GuiShowFilterTooltip(self, "Crafting Materials")</OnMouseEnter>
 									<OnMouseExit>IIfA:GuiHideTooltip(self)</OnMouseExit>
 									<OnMouseUp>IIfA:GuiOnFilterButton(self, button, "Materials", {ITEMTYPE_ARMOR_TRAIT, ITEMTYPE_BLACKSMITHING_MATERIAL, ITEMTYPE_BLACKSMITHING_RAW_MATERIAL, ITEMTYPE_BLACKSMITHING_BOOSTER, ITEMTYPE_CLOTHIER_MATERIAL, ITEMTYPE_CLOTHIER_RAW_MATERIAL, ITEMTYPE_CLOTHIER_BOOSTER, ITEMTYPE_ENCHANTING_RUNE_ASPECT, ITEMTYPE_ENCHANTING_RUNE_ESSENCE, ITEMTYPE_RUNE_POTENCY, ITEMTYPE_FISH, ITEMTYPE_FLAVORING, ITEMTYPE_INGREDIENT, ITEMTYPE_POISON_BASE, ITEMTYPE_POTION_BASE, ITEMTYPE_REAGENT, ITEMTYPE_RAW_MATERIAL, ITEMTYPE_WEAPON_TRAIT, ITEMTYPE_SPICE, ITEMTYPE_WOODWORKING_MATERIAL, ITEMTYPE_WOODWORKING_RAW_MATERIAL, ITEMTYPE_WOODWORKING_BOOSTER, ITEMTYPE_STYLE_MATERIAL})</OnMouseUp>
@@ -219,7 +219,7 @@
 								<Button name="$(parent)_Button5">
 									<Anchor point="TOPRIGHT" relativeTo="$(parent)_Button4" relativePoint="TOPRIGHT" offsetX="50" offsetY="0"/>
 									<Dimensions x="40" y="40" />
-									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized>
+<!--									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized> -->
 									<OnMouseEnter>IIfA:GuiShowFilterTooltip(self, "Furniture")</OnMouseEnter>
 									<OnMouseExit>IIfA:GuiHideTooltip(self)</OnMouseExit>
 									<OnMouseUp>IIfA:GuiOnFilterButton(self, button, "Specialized", {ITEMTYPE_FURNISHING, SPECIALIZED_ITEMTYPE_FURNISHING_CRAFTING_STATION, SPECIALIZED_ITEMTYPE_FURNISHING_LIGHT, SPECIALIZED_ITEMTYPE_FURNISHING_ORNAMENTAL, SPECIALIZED_ITEMTYPE_FURNISHING_SEATING, SPECIALIZED_ITEMTYPE_FURNISHING_TARGET_DUMMY})</OnMouseUp>
@@ -234,7 +234,7 @@
 								<Button name="$(parent)_Button6">
 									<Anchor point="TOPRIGHT" relativeTo="$(parent)_Button5" relativePoint="TOPRIGHT" offsetX="50" offsetY="0"/>
 									<Dimensions x="40" y="40" />
-									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized>
+<!--									<OnInitialized>IIfA_SetButtonFilterText(self)</OnInitialized> -->
 									<OnMouseEnter>IIfA:GuiShowFilterTooltip(self, "Miscellaneous")</OnMouseEnter>
 									<OnMouseExit>IIfA:GuiHideTooltip(self)</OnMouseExit>
 									<OnMouseUp>IIfA:GuiOnFilterButton(self, button, "Misc", {ITEMTYPE_GLYPH_ARMOR, ITEMTYPE_GLYPH_JEWELRY, ITEMTYPE_GLYPH_WEAPON, ITEMTYPE_SOUL_GEM, ITEMTYPE_SIEGE, ITEMTYPE_LURE, ITEMTYPE_TOOL, ITEMTYPE_REPAIR, ITEMTYPE_TRASH, ITEMTYPE_TROPHY, ITEMTYPE_COLLECTIBLE, ITEMTYPE_FISH, ITEMTYPE_TREASURE})</OnMouseUp>
@@ -897,6 +897,22 @@
 							<OnMouseUp>self.locked = true</OnMouseUp>
 							<OnValueChanged>IIfA:GuiOnSliderUpdate(self, value)</OnValueChanged>
 						</Slider>
+
+						<Control name="$(parent)_Counts" verticalAlignment="LEFT">
+							<Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" offsetY="3" />
+							<Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOMRIGHT" offsetY="3" />
+							<Dimensions y="26" />
+							<Controls>
+								<Label name="$(parent)_Items" mouseEnabled="false" font="ZoFontGameSmall" text="Items" >
+									<Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="0"/>
+									<Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOM" offsetX="0" offsetY="0"/>
+								</Label>
+								<Label name="$(parent)_Slots" mouseEnabled="false" font="ZoFontGameSmall" text="Slots" >
+									<Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="0" offsetY="0"/>
+									<Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOM" offsetX="0" offsetY="0"/>
+								</Label>
+							</Controls>
+						</Control>
 
 					</Controls>
 

--- a/IIfA/IIfABackpack.lua
+++ b/IIfA/IIfABackpack.lua
@@ -356,10 +356,12 @@ function IIfA:UpdateScrollDataLinesData()
 	local dataLines = {}
 	local DBv3 = IIfA.database
 	local itemLink, itemKey, iconFile, itemQuality, tempDataLine = nil
-	local itemTypeFilter, itemCount = 0
+	local itemTypeFilter
+	local itemCount
 	local match = false
 	local bWorn = false
 	local dbItem
+	local totItems = 0
 
 	if(DBv3)then
 		for itemKey, dbItem in pairs(DBv3) do
@@ -381,6 +383,7 @@ function IIfA:UpdateScrollDataLinesData()
 				local itemIcon = GetItemLinkIcon(itemLink)
 
 				local locationName, locData
+				local itemCount = 0
 				for locationName, locData in pairs(dbItem.locations) do
 					itemCount = itemCount + itemSum(locData)
 					if DoesInventoryMatchList(locationName, locData) then
@@ -405,6 +408,7 @@ function IIfA:UpdateScrollDataLinesData()
 
 				if(itemCount > 0) and matchFilter(dbItem.itemName, itemLink) and matchQuality(dbItem.itemQuality) and match then
 					table.insert(dataLines, tempDataLine)
+					totItems = totItems + (itemCount or 0)
 				end
 				match = false
 			end
@@ -414,6 +418,10 @@ function IIfA:UpdateScrollDataLinesData()
 	IIFA_GUI_ListHolder.dataLines = dataLines
 	sort(IIFA_GUI_ListHolder.dataLines)
 	IIFA_GUI_ListHolder.dataOffset = 0
+
+	-- even if the counts aren't visible, update them so they show properly if user turns them on
+	IIFA_GUI_ListHolder_Counts_Items:SetText("Item Count: " .. totItems)
+	IIFA_GUI_ListHolder_Counts_Slots:SetText("Appx. Slots Used: " .. #dataLines)
 
 end
 
@@ -942,7 +950,6 @@ function IIfA:FilterByItemName(control)
 	itemName = GetItemLinkName(control.itemLink)
 
 	IIfA.searchFilter = itemName
-	-- IIFA_GUI_SetNameOnly_Checked:SetHidden(true)
 	IIFA_GUI_SearchBox:SetText(itemName)
 	IIFA_GUI_SearchBoxText:SetHidden(true)
 	IIfA.bFilterOnSetName = false
@@ -968,7 +975,6 @@ function IIfA:FilterByItemSet(control)
 	end
 
 	IIfA.searchFilter = setName
-	-- IIFA_GUI_SetNameOnly_Checked:SetHidden(false)
 	IIFA_GUI_SearchBox:SetText(setName)
 	IIFA_GUI_SearchBoxText:SetHidden(true)
 	IIfA.bFilterOnSetName = true

--- a/IIfA/IIfAMenu.lua
+++ b/IIfA/IIfAMenu.lua
@@ -4,7 +4,7 @@ IIfA = IIfA
 local LAM = LibStub("LibAddonMenu-2.0")
 local LMP = LibStub("LibMediaProvider-1.0")
 
-local id, guildName, deleteHouse, restoreHouse, name 
+local id, guildName, deleteHouse, restoreHouse, name
 
 local function getCharacterInventories()
 
@@ -405,6 +405,18 @@ function IIfA:CreateOptionsMenu()
 			end,
 		},
 
+		{	-- checkbox: show item count/slot count stats
+			type = "checkbox",
+			tooltip = "Show Item Stats below list",
+			name = "Show Item Stats",
+			getFunc = function() return IIfA:GetSettings().showItemStats end,
+			setFunc = function(value)
+					IIfA:StatusAlert("[IIfA]:ItemStats[" .. tostring(value) .. "]")
+					IIfA:GetSettings().showItemStats = value
+					IIFA_GUI_ListHolder_Counts:SetHidden(not value)
+			end,
+		},
+
 		{
 			type = "dropdown",
 			name =  "Default Inventory Frame View",
@@ -447,7 +459,6 @@ function IIfA:CreateOptionsMenu()
 			setFunc = function(value)
 				IIfA:GetSettings().bFilterOnSetName = value
 				IIfA.bFilterOnSetName = value
-				-- IIFA_GUI_SetNameOnly_Checked:SetHidden(not value)
 			end,
 		}, -- checkbox end
 

--- a/IIfA/IIfASettingsAdapter.lua
+++ b/IIfA/IIfASettingsAdapter.lua
@@ -12,15 +12,12 @@ function IIfA:IgnoreCharacterInventory(value)
 	IIfA.data.ignoredCharInventories[IIfA.currentCharacterId] = value
 
 	IIfA.trackedBags[BAG_BACKPACK] = not value
-	task:Call(function()
-		if value then
-			IIfA:ClearLocationData(IIfA.currentCharacterId, BAG_BACKPACK)
-		else
-			IIfA:ScanCurrentCharacter()
-		end
-	end):Then(function()
-		IIfA:RefreshInventoryScroll()
-	end)
+	if value then
+		IIfA:ClearLocationData(IIfA.currentCharacterId, BAG_BACKPACK)
+	else
+		IIfA:ScanCurrentCharacter()
+	end
+	IIfA:RefreshInventoryScroll()
 end
 
 function IIfA:IsCharacterEquipIgnored()
@@ -31,16 +28,14 @@ function IIfA:IgnoreCharacterEquip(value)
 	IIfA.data.ignoredCharEquipment[IIfA.currentCharacterId] = value
 
 	IIfA.trackedBags[BAG_WORN] = not value
-	task:Call(function()
-		if value then
-			IIfA:ClearLocationData(IIfA.currentCharacterId, BAG_WORN)
-		else
-			IIfA:ScanCurrentCharacter()
-		end
-	end):Then(function()
-		IIfA:RefreshInventoryScroll()
-	end)
+	if value then
+		IIfA:ClearLocationData(IIfA.currentCharacterId, BAG_WORN)
+	else
+		IIfA:ScanCurrentCharacter()
+	end
+	IIfA:RefreshInventoryScroll()
 end
+
 function IIfA:GetCharacterList()
 	return IIfA.data.accountCharacters
 end
@@ -62,7 +57,7 @@ end
 
 function IIfA:SetSetNameFilterOnly(value)
 	IIfA.bFilterOnSetName = not IIfA.bFilterOnSetName
-	IIFA_GUI_SetNameOnly:SetState((IIfA.bFilterOnSetName and BSTATE_PRESSED) or BSTATE_NORMAL)
+	IIFA_GUI_Search_SetNameOnly:SetState((IIfA.bFilterOnSetName and BSTATE_PRESSED) or BSTATE_NORMAL)
     IIfA:RefreshInventoryScroll()
 end
 

--- a/IIfA/IIfA_Preload.lua
+++ b/IIfA/IIfA_Preload.lua
@@ -11,7 +11,7 @@ for stringId, stringValue in pairs(strings) do
 	SafeAddVersion(stringId, 1)
 end
 
-
+--[[ no longer needed
 function IIfA_SetButtonFilterText(control)
 	local buttonIdxNames = {
 		[1] = "All",
@@ -26,3 +26,4 @@ function IIfA_SetButtonFilterText(control)
 	local buttonIdx = control:GetName():gsub("IIFA_GUI_Header_Filter_Button", "") + 1
 	control.filterText = buttonIdxNames[buttonIdx]
 end
+--]]

--- a/IIfA/IIfA_xml_adapter.lua
+++ b/IIfA/IIfA_xml_adapter.lua
@@ -171,21 +171,25 @@ end
 -- click functions
 function IIfA:GuiOnFilterButton(control, mouseButton, filterGroup, filterTypes, filterTypeNames)
 	-- identify if this is main or sub filter clicked
+	local ctrlName = control:GetName()
 
-	local b_isMain = control:GetName():find("Sub") == nil
---[[
-	if mouseButton == MOUSE_BUTTON_INDEX_RIGHT then
-		if b_isMain then
-			IIfA.LastFilterControl = control
-			return IIfA:GuiOnFilterButton(IIFA_GUI_Header_Filter:GetChild(1), MOUSE_BUTTON_INDEX_LEFT, "All", nil)
-		else
-			IIfA.LastSubFilterControl = control
-			local parentIdx = control:GetParent():GetName():gsub("IIFA_GUI_Header_Subfilter_", IIfA.EMPTY_STRING)
-			local parentControl = IIFA_GUI_Header_Filter:GetChild(parentIdx+1)
-			return IIfA:GuiOnFilterButton(parentControl, MOUSE_BUTTON_INDEX_LEFT, parentControl.filterText)
+	local b_isMain = ctrlName:find("Sub") == nil
+
+	if mouseButton == MOUSE_BUTTON_INDEX_RIGHT and (ctrlName:sub(#ctrlName - 1, #ctrlName) == "10" or ctrlName:sub(#ctrlName, #ctrlName) ~= "0") then
+		ctrlName = ctrlName:sub(1, #ctrlName - 1)
+		if ctrlName:sub(#ctrlName, #ctrlName) == "1" then
+			ctrlName = ctrlName:sub(1, #ctrlName - 1)
+		end
+		ctrlName = ctrlName .. "0"
+		local myButton = WINDOW_MANAGER:GetControlByName(ctrlName, "")
+		if myButton then
+			local onMouseUpHandlerFunc = myButton:GetHandler("OnMouseUp")
+			if onMouseUpHandlerFunc and type(onMouseUpHandlerFunc) == "function" then
+ 				onMouseUpHandlerFunc(myButton, nil)
+				return
+			end
 		end
 	end
---]]
 
 	if b_isMain then
 		if IIfA.LastFilterControl ~= nil then

--- a/IIfA/IIfA_xml_adapter.lua
+++ b/IIfA/IIfA_xml_adapter.lua
@@ -498,7 +498,6 @@ function IIfA:RePositionFrame(settings)
 	IIFA_GUI_Header_GoldButton:SetHidden(bMinimize)
 	IIFA_GUI_Header_BagButton:SetHidden(bMinimize)
 	IIFA_GUI_Header_SortBar:SetHidden(bMinimize)
-	IIFA_GUI_SetNameOnly:SetHidden(bMinimize)
 
 	IIFA_GUI:ClearAnchors()
 	if bMinimize then


### PR DESCRIPTION
line 519 crash fixed; heavy armor selected dropdown list has proper slots listed; mouseover on equipped items shows proper counts for poisons and other hand items (weaps and offhand weaps)

gui layout issues fixed (no more overlaps), item detail dropdown filter back where it came from (more or less)

debug info in datacollection line 104 moved to line 102 so user can debug better

item/slot counts, right click on filter bar will reset to 'all' for that bar, misc task removals to minimize background task occuring while user actively mousing

version changed to 3.13
