### PR TITLE
tooltip divider will now always match frame color (stolen or not) 

### DIFF
--- a/IIfA/IIfATooltip.lua
+++ b/IIfA/IIfATooltip.lua
@@ -43,7 +43,7 @@ function IIfA:CreateTooltips()
 	ZO_PreHookHandler(ItemTooltip, 'OnAddGameData', IIfA_TooltipOnTwitch)
 	ZO_PreHookHandler(ItemTooltip, 'OnHide', IIfA_HideTooltip)
 
-	ZO_PreHook("ZO_PopupTooltip_SetLink", function(itemLink) IIfA.TooltipLink = itemLink IIfA:DebugOut("Prehook PT Setlink - " .. itemLink) end)
+	ZO_PreHook("ZO_PopupTooltip_SetLink", function(itemLink) IIfA.TooltipLink = itemLink  end)
 
 	IIfA:SetTooltipFont(IIfA:GetSettings().in2TooltipsFont)
 end


### PR DESCRIPTION
new way to find first div and sets texture not color
removed stray debugout