### PR TITLE
Fixes two minor resizing bugs

### DIFF
--- a/IIfA/IIfA.xml
+++ b/IIfA/IIfA.xml
@@ -5,10 +5,11 @@
 			<Anchor point="TOPRIGHT" relativeTo="GUI_ROOT" relativePoint="TOPRIGHT" offsetX="-25" offsetY="40" />
 
 			<OnMoveStop>IIfA:SaveFrameInfo("onMoveStop")</OnMoveStop>
+			<OnResizeStart> IIfA:onResizeStart() </OnResizeStart>
 			<OnResizeStop>IIfA:onResizeStop()</OnResizeStop>
-
+			
 			<Controls>
-				<Backdrop name="$(parent)_BG" inherits="ZO_DefaultBackdrop" ></Backdrop>
+				<Backdrop name="$(parent)_BG" inherits="ZO_DefaultBackdrop" > <AnchorFill/> </Backdrop>
 
 				<Control name="$(parent)_Header" hidden="false" resizeToFitDescendents="false" >
 					<Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT"/>

--- a/IIfA/IIfA_xml_adapter.lua
+++ b/IIfA/IIfA_xml_adapter.lua
@@ -440,9 +440,16 @@ function IIfA:GuiResizeLines()
 	end
 end
 
+function IIfA:onResizeStart()
+	EVENT_MANAGER:RegisterForUpdate(IIfA.name.."OnWindowResize", 50,function() IIfA:GuiResizeScroll() if not IIfA:GetSceneSettings().docked then
+		IIfA:UpdateInventoryScroll()
+	end end)
+end
+
 function IIfA:onResizeStop()
 	-- if you resize the box, you need to resize the list to go with it
 	-- local sceneName = IIfA:GetCurrentSceneName()
+	EVENT_MANAGER:UnregisterForUpdate(IIfA.name.."OnWindowResize")
 	local settings = IIfA:GetSceneSettings()
 
 	IIfA:SaveFrameInfo("onResizeStop")
@@ -452,8 +459,6 @@ function IIfA:onResizeStop()
 		IIfA:UpdateInventoryScroll()
 	end
 end
-
-
 
 -- put separate dock/minimize/restore sizing code into unified function so all resizing gets done in one place, one time
 function IIfA:RePositionFrame(settings)


### PR DESCRIPTION
Fixes a bug where the backdrop was not filling the top level control properly. This does create some crowding issues with other controls, where they are too close to the edge.

Fixes a bug where when resizing the window, the scroll list did not resize until the resizing was done.