### PR TITLE
Baertram - Fixes 25.06.2018

### DIFF
--- a/IIfA/IIfABackpack.lua
+++ b/IIfA/IIfABackpack.lua
@@ -748,6 +748,8 @@ p("OnChestSelect '<<1>>' - <<2>>", choiceText, choice)
 				if cName == self.EMPTY_STRING then
 					cName = GetCollectibleName(cId)
 				end
+                		--remove gender specific characters from house bank chest name
+                		cName = zo_strformat("<<C:1>>", cName)
 				if cName == choiceText then
 					IIfA:SetInventoryListFilter("Housing Storage", ctr)
 					break
@@ -779,6 +781,8 @@ p("OnChestSelect '<<1>>' - <<2>>", choiceText, choice)
 				if cName == self.EMPTY_STRING then
 					cName = GetCollectibleName(cId)
 				end
+                		--remove gender specific characters from house bank chest name
+                		cName = zo_strformat("<<C:1>>", cName)
 				entry = comboBox:CreateItemEntry(cName, OnChestSelect)
 				comboBox:AddItem(entry)
 			end

--- a/IIfA/IIfADataCollection.lua
+++ b/IIfA/IIfADataCollection.lua
@@ -80,8 +80,8 @@ function IIfA:CollectGuildBank(curGuild)
 		end
 	end
 
-	SelectGuildBank(CurGB)
-	local count = 0
+	SelectGuildBank(curGB)
+	local itemCount = 0
 
 	if(IIfA.data.guildBanks[curGuild] == nil) then
 		IIfA.data.guildBanks[curGuild] = {}
@@ -95,7 +95,7 @@ function IIfA:CollectGuildBank(curGuild)
 		IIfA.BagSlotInfo = IIfA.BagSlotInfo or {}
 		p("Collect guild bank - <<1>>", curGuild)
 		local guildData = IIfA.data.guildBanks[curGuild]
-		local itemCount, i, slotIndex
+		local i, slotIndex
 		itemCount = 0
 		slotIndex = ZO_GetNextBagSlotIndex(BAG_GUILDBANK, nil)
 		while slotIndex do

--- a/IIfA/IIfASettingsAdapter.lua
+++ b/IIfA/IIfASettingsAdapter.lua
@@ -137,7 +137,10 @@ end
 function IIfA:GetTrackingWithHouseNames()
 	local ret = {}
 	for collectibleId, trackIt in pairs(IIfA.data.collectHouseData) do
-		ret[GetCollectibleName(collectibleId)] = true
+        local collectibleName = GetCollectibleName(collectibleId)
+        --remove gender specific characters from house name
+        collectibleName = zo_strformat("<<C:1>>", collectibleName)
+		ret[collectibleName] = true
 	end
 	return ret
 end
@@ -147,6 +150,8 @@ function IIfA:RebuildHouseMenuDropdowns()
 	local ignored = {}
 	for collectibleId, trackIt in pairs(IIfA.data.collectHouseData) do
 		local collectibleName = GetCollectibleName(collectibleId)
+		--remove gender specific characters from house name
+        collectibleName = zo_strformat("<<C:1>>", collectibleName)
 		-- cache house name for lookup
 		IIfA.houseNameToIdTbl[collectibleName] = collectibleId
 		local targetTable = (trackIt and tracked) or ignored
@@ -154,8 +159,7 @@ function IIfA:RebuildHouseMenuDropdowns()
 	end
 	IIfA.houseNamesIgnored = ignored
 	IIfA.houseNamesTracked = tracked
-end
-function IIfA:GetIgnoredHouseNames()
+endfunction IIfA:GetIgnoredHouseNames()
 	if nil == IIfA.houseNamesIgnored then
 		IIfA:RebuildHouseMenuDropdowns()
 	end

--- a/IIfA/IIfA_xml_adapter.lua
+++ b/IIfA/IIfA_xml_adapter.lua
@@ -508,7 +508,7 @@ function IIfA:RePositionFrame(settings)
 	if bMinimize then
 		IIFA_GUI:SetResizeHandleSize(0)
 		-- have to change the constraints, it even constrains resizing by code, not just resize by sizing handles
-   		IIFA_GUI:SetDimensionConstraints(IIfA.minWidth, 33, -1, 1400)
+   		IIFA_GUI:SetDimensionConstraints(IIfA.minWidth, 44, -1, 1400)
 
 		IIFA_GUI:SetHeight(33)
 		IIFA_GUI:SetWidth(settings.width)


### PR DESCRIPTION
-Fixed miss-spelled variable and missing variable (defined local in a func but accessed outside for GuildBankScan)
-Fixed house bank gender specific characters on non-en clients (LAM house dropdowns)
-Fixed house bank's chest gender specific characters on non-en clients (inventory filter dropdown)
-Fixed height of minimized IIfA inventory constraints to include the button textures again (they were overlaying the bottom border of the minimized window)