### PR TITLE
-Added API check at XML OnInitialize to prevent nil error at ZO_EditD…

### DIFF
--- a/IIfA/IIfA.xml
+++ b/IIfA/IIfA.xml
@@ -982,7 +982,9 @@
                 <EditBox name="$(parent)Box" inherits="ZO_DefaultEditForBackdrop">
                   <OnTextChanged>IIfA:GuiOnSearchboxText(self)</OnTextChanged>
                   <OnInitialized>
-                    ZO_EditDefaultText_Initialize(self, "Filter by text search")
+                    if GetAPIVersion() >= 101035 then
+                      ZO_EditDefaultText_Initialize(self, "Filter by text search")
+                    end
                   </OnInitialized>
                 </EditBox>
               </Controls>

--- a/IIfA/IIfA.xml
+++ b/IIfA/IIfA.xml
@@ -979,7 +979,7 @@
               <Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="0" offsetY="5"/>
               <OnInitialized>self:SetHeight(30)</OnInitialized>
               <Controls>
-                <EditBox name="$(parent)Box" inherits="ZO_DefaultEditForBackdrop">
+                <EditBox name="$(parent)Box" inherits="ZO_DefaultEditForBackdrop" defaultText="Filter by text search">
                   <OnTextChanged>IIfA:GuiOnSearchboxText(self)</OnTextChanged>
                   <OnInitialized>
                     if GetAPIVersion() >= 101035 then

--- a/IIfA/IIfABackpack.lua
+++ b/IIfA/IIfABackpack.lua
@@ -1115,7 +1115,9 @@ function IIfA:FilterByItemName(control)
   local itemName= zo_strformat(SI_TOOLTIP_ITEM_NAME, GetItemLinkName(control.itemLink))
   IIfA.searchFilter = checkSearchFilter(itemName)
   IIfA.GUI_SearchBox:SetText(IIfA.searchFilter)
-  IIfA.GUI_SearchBoxText:SetHidden(true)
+  if IIfA.GUI_SearchBoxText ~= nil then
+    IIfA.GUI_SearchBoxText:SetHidden(true)
+  end
   IIfA.bFilterOnSetName = false
   IIfA:RefreshInventoryScroll()
 end
@@ -1132,7 +1134,9 @@ function IIfA:FilterByItemSet(control, setName)
     IIfA.searchFilter = checkSearchFilter(setName)
     -- fill in the GUI portion here
     IIfA.GUI_SearchBox:SetText(IIfA.searchFilter)
-    IIfA.GUI_SearchBoxText:SetHidden(true)
+    if IIfA.GUI_SearchBoxText ~= nil then
+      IIfA.GUI_SearchBoxText:SetHidden(true)
+    end
     IIfA.bFilterOnSetName = true
     IIfA:RefreshInventoryScroll()
   end

--- a/IIfA/IIfA_xml_adapter.lua
+++ b/IIfA/IIfA_xml_adapter.lua
@@ -326,7 +326,9 @@ function IIfA:ApplySearchText(text)
     return articelStripped, textWithoutArticle
   end
 
-  IIfA.GUI_SearchBoxText:SetHidden(text ~= nil and text > IIfA.EMPTY_STRING)
+  if IIfA.GUI_SearchBoxText ~= nil then
+    IIfA.GUI_SearchBoxText:SetHidden(text ~= nil and text > IIfA.EMPTY_STRING)
+  end
 
   local searchTextLower = zo_strlower(text)
   local foundCount = updateSearchTextFilterAndDoSearch(searchTextLower)
@@ -353,7 +355,9 @@ end
 
 function IIfA:GuiOnSearchBoxClear(control)
   IIfA.GUI_SearchBox:SetText(IIfA.EMPTY_STRING)
-  IIfA.GUI_SearchBoxText:SetHidden(false)
+  if IIfA.GUI_SearchBoxText ~= nil then
+    IIfA.GUI_SearchBoxText:SetHidden(false)
+  end
   IIfA.searchFilter = IIfA.EMPTY_STRING
   IIfA:RefreshInventoryScroll()
 end


### PR DESCRIPTION
…efaultText_Initialize due to missing label control for the default text -> Was only available "on live server" if inheritance to ZO_EditDefaultText was used! Will be available one PTS again autoamtically

-Added nil checks to xml adapter and backpack:     if IIfA.GUI_SearchBoxText ~= nil then
This is the label control for the live server's default editbox text

live will be missing the default text "Filter by text search" now, but PTS and future live will re-show and work properly again